### PR TITLE
Introduce pre and post scheduled ops

### DIFF
--- a/src/bdm-simulation.cc
+++ b/src/bdm-simulation.cc
@@ -10,6 +10,7 @@
 //
 // -----------------------------------------------------------------------------
 
+#include <fstream>
 #include <iostream>
 
 #include "core/operation/operation_registry.h"
@@ -17,6 +18,7 @@
 
 #include "bdm-simulation.h"
 #include "categorical-environment.h"
+#include "custom-operations.h"
 #include "population-initialization.h"
 #include "sim-param.h"
 #include "visualize.h"
@@ -584,10 +586,29 @@ int Simulate(int argc, const char** argv) {
   // Don't run load balancing, not working with custom environment.
   scheduler->UnscheduleOp(scheduler->GetOps("load balancing")[0]);
 
+  // Add a operation that resets the number of casual partners at the beginning
+  // of each iteration
+  OperationRegistry::GetInstance()->AddOperationImpl(
+      "ResetCasualPartners", OpComputeTarget::kCpu, new ResetCasualPartners());
+  auto* reset_casual_partners = NewOperation("ResetCasualPartners");
+  scheduler->ScheduleOp(reset_casual_partners, OpType::kPreSchedule);
+
+  // Add operation that extracts arbitrary information at the end of each
+  // iteration
+  OperationRegistry::GetInstance()->AddOperationImpl(
+      "ExtractInformation", OpComputeTarget::kCpu,
+      new ReductionOp<PopulationData>());
+  auto* extract_information = NewOperation("ExtractInformation");
+  auto* extract_information_impl =
+      extract_information->GetImplementation<ReductionOp<PopulationData>>();
+  extract_information_impl->Initialize(new GetPopulationDataThreadLocal(),
+                                       new CombinePopulationData());
+  scheduler->ScheduleOp(extract_information);
+
   // Run simulation for <number_of_iterations> timesteps
   {
     Timing timer_sim("RUNTIME");
-    simulation.GetScheduler()->Simulate(sparam->number_of_iterations);
+    scheduler->Simulate(sparam->number_of_iterations);
   }
 
   {
@@ -596,6 +617,24 @@ int Simulate(int argc, const char** argv) {
     // Generate ROOT plot to visualize the number of healthy and infected
     // individuals over time.
     PlotAndSaveTimeseries();
+  }
+
+  // Here one could do something with the results of the extracted information
+  // e.g. print to stdout or export to some files.
+  {
+    const std::vector<PopulationData>& panel_data =
+        extract_information_impl->GetResults();
+    std::ofstream filewriter;
+    int local_cntr = 1;
+    for (auto& p : panel_data) {
+      std::string filename = simulation.GetOutputDir() + "/population_data_" +
+                             std::to_string(local_cntr) + ".out";
+      std::cout << filename << std::endl;
+      filewriter.open(filename);
+      p.Print(filewriter);
+      filewriter.close();
+      local_cntr++;
+    }
   }
 
   // DEBUG - AM - TO DO: Works only when selection depended soloely on locations

--- a/src/custom-operations.cc
+++ b/src/custom-operations.cc
@@ -1,0 +1,102 @@
+// -----------------------------------------------------------------------------
+//
+// Copyright (C) 2021 CERN and the University of Geneva for the benefit of the
+// BioDynaMo collaboration. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// See the LICENSE file distributed with this work for details.
+//
+// -----------------------------------------------------------------------------
+
+#include "custom-operations.h"
+
+namespace bdm {
+
+void ResetCasualPartners::operator()() {
+  // L2F converts a lambda call to a bdm::functor. We introduce this functor
+  // because the ResourceManager::ForEachAgentParallel expects a functor.
+  auto reset_functor = L2F([](Agent* agent) {
+    auto* person = dynamic_cast<Person*>(agent);
+    person->ResetCasualPartners();
+  });
+
+  // Execute the functor for each agent in parallel.
+  auto* sim = Simulation::GetActive();
+  auto* rm = sim->GetResourceManager();
+  rm->ForEachAgentParallel(reset_functor);
+}
+
+PopulationData& PopulationData::operator+=(
+    const PopulationData& other_population) {
+  // add vectors for age_male
+  std::transform(this->age_male.begin(), this->age_male.end(),
+                 other_population.age_male.begin(), this->age_male.begin(),
+                 std::plus<int>());
+  // add vectors infected male
+  std::transform(this->infected_male.begin(), this->infected_male.end(),
+                 other_population.infected_male.begin(),
+                 this->infected_male.begin(), std::plus<int>());
+  // add vectors age_female
+  std::transform(this->age_female.begin(), this->age_female.end(),
+                 other_population.age_female.begin(), this->age_female.begin(),
+                 std::plus<int>());
+  // add vectors infected_female
+  std::transform(this->infected_female.begin(), this->infected_female.end(),
+                 other_population.infected_female.begin(),
+                 this->infected_female.begin(), std::plus<int>());
+  // add up healthy_male
+  this->healthy_male += other_population.healthy_male;
+  // add up healthy_female
+  this->healthy_female += other_population.healthy_female;
+
+  return *this;
+}
+
+void PopulationData::Print(std::ostream& out) const {
+  out << "Population Information: \n";
+  out << "healthy_male    : " << healthy_male << " \n";
+  out << "healthy_female  : " << healthy_female << " \n";
+  out << "infected_male   : "
+      << std::accumulate(infected_male.begin(), infected_male.end(), 0);
+  out << "\ninfected_female : "
+      << std::accumulate(infected_female.begin(), infected_female.end(), 0);
+  out << "\n\nage        male      female\n";
+  for (int age = 0; age < std::max(age_female.size(), age_male.size()); age++) {
+    out << std::setw(3) << age << "    " << std::setw(8) << age_male[age]
+        << "    " << std::setw(8) << age_female[age] << " \n";
+  }
+  out << std::endl;
+}
+
+void GetPopulationDataThreadLocal::operator()(Agent* agent,
+                                              PopulationData* tl_pop) {
+  auto* person = bdm_static_cast<Person*>(agent);
+  if (person->sex_ == Sex::kMale) {
+    tl_pop->age_male[static_cast<int>(person->age_)] += 1;
+    if (person->state_ == GemsState::kHealthy) {
+      tl_pop->healthy_male += 1;
+    } else {
+      tl_pop->infected_male[person->state_ - 1] += 1;
+    }
+  } else {
+    tl_pop->age_female[static_cast<int>(person->age_)] += 1;
+    if (person->state_ == GemsState::kHealthy) {
+      tl_pop->healthy_female += 1;
+    } else {
+      tl_pop->infected_female[person->state_ - 1] += 1;
+    }
+  }
+}
+
+PopulationData CombinePopulationData::operator()(
+    const SharedData<PopulationData>& tl_populations) {
+  // Get object for total population
+  PopulationData total_pop;
+  for (PopulationData tl_population : tl_populations) {
+    total_pop += tl_population;
+  }
+  return total_pop;
+}
+}  // namespace bdm

--- a/src/custom-operations.h
+++ b/src/custom-operations.h
@@ -1,0 +1,75 @@
+// -----------------------------------------------------------------------------
+//
+// Copyright (C) 2022 CERN and the University of Geneva for the benefit of the
+// BioDynaMo collaboration. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// See the LICENSE file distributed with this work for details.
+//
+// -----------------------------------------------------------------------------
+
+#ifndef CUSTOM_OPERATIONS_H_
+#define CUSTOM_OPERATIONS_H_
+
+#include "core/operation/operation.h"
+#include "core/resource_manager.h"
+#include "person.h"
+
+namespace bdm {
+
+/// Operation to reset the number of casual partner for each agent (in parallel)
+struct ResetCasualPartners : public StandaloneOperationImpl {
+  BDM_OP_HEADER(ResetCasualPartners);
+  void operator()() override;
+};
+
+/// The struct population data describes the information that is extracted from
+/// the population of agents at each timestep.
+struct PopulationData {
+  // Constructor to obtain correct size of zero-initialized vectors.
+  PopulationData()
+      : healthy_female(0),
+        healthy_male(0),
+        infected_female(GemsState::kGemsLast, 0),
+        infected_male(GemsState::kGemsLast, 0),
+        age_female(120, 0),
+        age_male(120, 0) {}
+
+  // member variables
+  int healthy_female;
+  int healthy_male;
+  std::vector<int> infected_female;
+  std::vector<int> infected_male;
+  std::vector<int> age_female;
+  std::vector<int> age_male;
+
+  // Inplace-Add for Population data. The idea is to fill one struct
+  // PopulationData per thread, the inplace add is used to combine the
+  // information. See CombinePopulationData::operator()
+  PopulationData& operator+=(const PopulationData& other_population);
+
+  // Print the population data to std::out or a file. Similar functions could be
+  // used to export to CSV or similar fileformats.
+  void Print(std::ostream& out) const;
+};
+
+/// Functor to extract the PopulationData from agents. In the main simulation,
+/// we combine it with a ReductionOp. This ReductionOp iterates over all agents
+/// with all available threads. Each thread executes the operator().
+struct GetPopulationDataThreadLocal
+    : public Functor<void, Agent*, PopulationData*> {
+  void operator()(Agent* agent, PopulationData* tl_pop);
+};
+
+/// Functor to combine multiple thread local PopulationData results into one.
+struct CombinePopulationData
+    : public Functor<PopulationData, const SharedData<PopulationData>&> {
+  PopulationData operator()(
+      const SharedData<PopulationData>& tl_populations) override;
+};
+
+}  // namespace bdm
+
+#endif  // CUSTOM_OPERATIONS_H_

--- a/src/person.h
+++ b/src/person.h
@@ -261,6 +261,9 @@ class Person : public Cell {
 
   int GetNumberOfChildren() { return children_.size(); }
 
+  // Restet the counter of casual partners to zero
+  void ResetCasualPartners() { no_casual_partners_ = 0; }
+
   // Activates the protection of an agent against death.
   void LockProtection() { protected_ = true; }
   // Deactivates the protection of an agent against death.


### PR DESCRIPTION
This PR introduces a `PreSchedule` Op and a `PostSchedule` Op. The former resets the number of all casual partners to 0, the latter extracts information for the agent population in parallel.